### PR TITLE
fix #30

### DIFF
--- a/includes/class-alg-wc-price-by-user-role-core.php
+++ b/includes/class-alg-wc-price-by-user-role-core.php
@@ -110,7 +110,7 @@ if ( ! class_exists( 'Alg_WC_Price_By_User_Role_Core' ) ) :
 		 * @param array $query Main Query.
 		 */
 		public function alg_wc_price_by_user_role_products_by_price_filter( $query ) {
-			if ( $query->is_main_query() && isset( $_GET['max_price'] ) && isset( $_GET['min_price'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			if ( $query->is_main_query() && isset( $_GET['max_price'] ) && isset( $_GET['min_price'] ) && ! apply_filters( 'alg_wc_price_by_user_role_products_by_price_filter', false ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$product_ids = wc_get_products(
 					array(
 						'return' => 'ids',
@@ -139,6 +139,11 @@ if ( ! class_exists( 'Alg_WC_Price_By_User_Role_Core' ) ) :
 		 * @param int $min_price Min Price.
 		 */
 		public function alg_wc_price_by_user_role_min_price( $min_price ) {
+
+			if ( ! apply_filters( 'alg_wc_price_by_user_role_min_price', true )  ) {
+				return $min_price;
+			}
+
 			$product_ids = wc_get_products(
 				array(
 					'return' => 'ids',
@@ -173,6 +178,11 @@ if ( ! class_exists( 'Alg_WC_Price_By_User_Role_Core' ) ) :
 		 * @param int $max_price Max price.
 		 */
 		public function alg_wc_price_by_user_role_max_price( $max_price ) {
+
+			if ( ! apply_filters( 'alg_wc_price_by_user_role_max_price', true )  ) {
+				return $max_price;
+			}
+
 			$product_ids = wc_get_products(
 				array(
 					'return' => 'ids',


### PR DESCRIPTION
The client was having more than 1k products on his store and getting min and max price by role was causing this slowness. To speedup, I have added filters to avoid those calculations.

Along with that, we have share the following code with the client that needs to be placed in the functions.php file of the currently active theme.

```
add_filter( 'alg_wc_price_by_user_role_min_price', '__return_false' );
add_filter( 'alg_wc_price_by_user_role_max_price', '__return_false' );
add_filter( 'alg_wc_price_by_user_role_products_by_price_filter', '__return_false' );
```